### PR TITLE
Update the README, rename some classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,9 @@ TSWLatexianTemp*
 # VSCode
 .vscode
 
+# Pycharm
+.idea
+
 # Python
 .venv
 __pycache__

--- a/source/openqasm/README.md
+++ b/source/openqasm/README.md
@@ -9,7 +9,7 @@ This directory consists of:
 
 * ast.py: The AST nodes.
 * parser/antlr: A parser based on Antlr grammar and reference parser also found in this repo.
-  It walks the ANTLR parse tree to generate the AST tree.
+  It walks the ANTLR parse tree to generate the AST.
 * visitor.py: A base AST visitor and transformer.
 * tests: A set of unit tests.
 

--- a/source/openqasm/README.md
+++ b/source/openqasm/README.md
@@ -1,14 +1,17 @@
-# OpenNode: a reference OpenQASM 3.0 AST in Python
+# A reference OpenQASM 3.0 AST in Python
 
-This directory contains a reference AST implementation for OpenQASM 3.0 in Python. It consists of:
+This Abstract Syntax Tree (AST) is intended to help with writing compiler passes for OpenQASM 3.0 in
+Python. It aims to have no dependencies for users who consume the Python tree structure, and minimal
+dependencies for parsing a string to this tree structure. The AST is simpler than a Concrete Syntax
+Tree (CST) which preserves comments, spacing, etc for use by editor plugins.
+
+This directory consists of:
 
 * ast.py: The AST nodes.
 * parser/antlr: A parser based on Antlr grammar and reference parser also found in this repo.
-It walks the ANTLR parse tree to generate the AST tree.
-* ast_visitor: A base AST visitor and an example showing how to implement compiler passes
-using the visitor.
+  It walks the ANTLR parse tree to generate the AST tree.
+* visitor.py: A base AST visitor and transformer.
 * tests: A set of unit tests.
-
 
 ## Developer setup
 

--- a/source/openqasm/ast.py
+++ b/source/openqasm/ast.py
@@ -19,7 +19,7 @@ class Span:
 
 
 @dataclass
-class OpenNode:
+class QasmNode:
     """Base class for all OpenQASM 3 nodes"""
 
     span: Optional[Span] = field(init=False, default=None, compare=False)
@@ -31,7 +31,7 @@ class OpenNode:
 
 
 @dataclass
-class Program(OpenNode):
+class Program(QasmNode):
     """
     An entire OpenQASM 3 program represented by a list of top level statements
     """
@@ -43,7 +43,7 @@ class Program(OpenNode):
 
 
 @dataclass
-class Include(OpenNode):
+class Include(QasmNode):
     """
     An include statement
     """
@@ -51,7 +51,7 @@ class Include(OpenNode):
     filename: str
 
 
-class Statement(OpenNode):
+class Statement(QasmNode):
     """A statement: anything that can appear on its own line"""
 
 
@@ -156,7 +156,7 @@ class ExternDeclaration(Statement):
     return_type: Optional[ClassicalType]
 
 
-class Expression(OpenNode):
+class Expression(QasmNode):
     """An expression: anything that returns a value"""
 
 
@@ -425,7 +425,7 @@ class GateModifierName(Enum):
 
 
 @dataclass
-class QuantumGateModifier(OpenNode):
+class QuantumGateModifier(QasmNode):
     """
     A quantum gate modifier
 
@@ -518,7 +518,7 @@ class QuantumMeasurementAssignment(Statement):
 
 
 @dataclass
-class ClassicalArgument(OpenNode):
+class ClassicalArgument(QasmNode):
     """
     Classical argument for a gate or subroutine declaration
     """
@@ -575,7 +575,7 @@ class ConstantDeclaration(Statement):
     init_expression: Expression
 
 
-class ClassicalType(OpenNode):
+class ClassicalType(QasmNode):
     """
     Base class for classical type
     """
@@ -683,7 +683,7 @@ class ComplexType(ClassicalType):
     base_type: Union[IntType, UintType, FloatType, AngleType]
 
 
-class IndexIdentifier(OpenNode):
+class IndexIdentifier(QasmNode):
     """
     Quantum or classical identifier,
     indexed or not indexed.
@@ -750,7 +750,7 @@ class Slice(IndexIdentifier):
 
 
 @dataclass
-class RangeDefinition(OpenNode):
+class RangeDefinition(QasmNode):
     """
     Range definition.
 
@@ -834,7 +834,7 @@ class SubroutineDefinition(Statement):
 
 
 @dataclass
-class QuantumArgument(OpenNode):
+class QuantumArgument(QasmNode):
     """
     Quantum argument in subroutine definition
 
@@ -997,7 +997,7 @@ class Box(TimingStatement):
 
 
 @dataclass
-class DurationOf(OpenNode):
+class DurationOf(QasmNode):
     """
     Duration Of
 

--- a/source/openqasm/parser/antlr/qasm_parser.py
+++ b/source/openqasm/parser/antlr/qasm_parser.py
@@ -50,8 +50,8 @@ from openqasm.ast import (
     IntType,
     IODeclaration,
     IOKeyword,
-    OpenNode,
     Program,
+    QasmNode,
     QuantumArgument,
     QuantumGate,
     QuantumGateModifier,
@@ -84,14 +84,14 @@ from openqasm.ast import (
 _TYPE_NODE_INIT = {"int": IntType, "uint": UintType, "float": FloatType, "angle": AngleType}
 
 
-def parse(openqasm3_program: str) -> OpenNode:
+def parse(openqasm3_program: str) -> QasmNode:
     lexer = qasm3Lexer(InputStream(openqasm3_program))
     stream = CommonTokenStream(lexer)
     parser = qasm3Parser(stream)
 
     tree = parser.program()
 
-    return OpenNodeVisitor().visitProgram(tree)
+    return QasmNodeVisitor().visitProgram(tree)
 
 
 def get_span(node: Union[ParserRuleContext, TerminalNode]) -> Span:
@@ -102,10 +102,10 @@ def get_span(node: Union[ParserRuleContext, TerminalNode]) -> Span:
         return Span(node.symbol.line, node.symbol.start, node.symbol.line, node.symbol.stop)
 
 
-def add_span(open_node: OpenNode, span: Span) -> OpenNode:
+def add_span(node: QasmNode, span: Span) -> QasmNode:
     """Set the span of a node and return the node"""
-    open_node.span = span
-    return open_node
+    node.span = span
+    return node
 
 
 def combine_span(first: Span, second: Span):
@@ -128,7 +128,7 @@ def span(func):
     return wrapped
 
 
-class OpenNodeVisitor(qasm3Visitor):
+class QasmNodeVisitor(qasm3Visitor):
     @span
     def visitProgram(self, ctx: qasm3Parser.ProgramContext):
 

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -36,8 +36,8 @@ from openqasm.ast import (
     IntType,
     IODeclaration,
     IOKeyword,
-    OpenNode,
     Program,
+    QasmNode,
     QuantumArgument,
     QuantumGateModifier,
     QuantumMeasurement,
@@ -62,13 +62,13 @@ from openqasm.ast import (
     UnaryOperator,
 )
 from openqasm.parser.antlr.qasm_parser import parse, Span
-from openqasm.ast_visitor.ast_visitor import NodeVisitor
+from openqasm.visitor import QasmVisitor
 
 
-class SpanGuard(NodeVisitor):
+class SpanGuard(QasmVisitor):
     """Ensure that we did not forget to set spans when we add new AST nodes"""
 
-    def visit(self, node: OpenNode):
+    def visit(self, node: QasmNode):
         try:
             assert node.span is not None
             return super().visit(node)

--- a/source/openqasm/visitor.py
+++ b/source/openqasm/visitor.py
@@ -1,11 +1,11 @@
 from typing import Optional, TypeVar, Generic
 
-from openqasm.ast import OpenNode
+from openqasm.ast import QasmNode
 
 T = TypeVar("T")
 
 
-class NodeVisitor(Generic[T]):
+class QasmVisitor(Generic[T]):
     """
     A node visitor base class that walks the abstract syntax tree and calls a
     visitor function for every node found.  This function may return a value
@@ -19,7 +19,7 @@ class NodeVisitor(Generic[T]):
     information that we do not want to hold in either the AST or the visitor themselves.
     """
 
-    def visit(self, node: OpenNode, context: Optional[T] = None):
+    def visit(self, node: QasmNode, context: Optional[T] = None):
         """Visit a node."""
         method = "visit_" + node.__class__.__name__
         visitor = getattr(self, method, self.generic_visit)
@@ -29,42 +29,42 @@ class NodeVisitor(Generic[T]):
         else:
             return visitor(node)
 
-    def generic_visit(self, node: OpenNode, context: Optional[T] = None):
+    def generic_visit(self, node: QasmNode, context: Optional[T] = None):
         """Called if no explicit visitor function exists for a node."""
         for value in node.__dict__.values():
             if not isinstance(value, list):
                 value = [value]
             for item in value:
-                if isinstance(item, OpenNode):
+                if isinstance(item, QasmNode):
                     if context:
                         self.visit(item, context)
                     else:
                         self.visit(item)
 
 
-class NodeTransformer(NodeVisitor[T]):
+class QasmTransformer(QasmVisitor[T]):
     """
-    A :class:`NodeVisitor` subclass that walks the abstract syntax tree and
+    A :class:`QasmVisitor` subclass that walks the abstract syntax tree and
     allows modification of nodes.
 
     Modified from the implementation in ast.py in the Python standard library
     """
 
-    def generic_visit(self, node: OpenNode, context: Optional[T] = None) -> OpenNode:
+    def generic_visit(self, node: QasmNode, context: Optional[T] = None) -> QasmNode:
         for field, old_value in node.__dict__.items():
             if isinstance(old_value, list):
                 new_values = []
                 for value in old_value:
-                    if isinstance(value, OpenNode):
+                    if isinstance(value, QasmNode):
                         value = self.visit(value, context) if context else self.visit(value)
                         if value is None:
                             continue
-                        elif not isinstance(value, OpenNode):
+                        elif not isinstance(value, QasmNode):
                             new_values.extend(value)
                             continue
                     new_values.append(value)
                 old_value[:] = new_values
-            elif isinstance(old_value, OpenNode):
+            elif isinstance(old_value, QasmNode):
                 new_node = self.visit(old_value, context) if context else self.visit(old_value)
                 if new_node is None:
                     delattr(node, field)


### PR DESCRIPTION
Changes:
- Add an introduction to the README
- Rename `OpenNode` to `QasmNode`
- Rename `NodeVisitor/Transformer` to `QasmVisitor/Transformer`
- Move `visitor.py` to the top level so that the import is shorter

/cc @shiyunon @aspcompiler @jakelishman